### PR TITLE
feat: re-implement translating feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "dependencies": {
         "@babel/core": "^7.12.9",
         "@babel/generator": "^7.12.5",
-        "esm": "^3.2.25",
         "vm2": "^3.9.2"
     }
 }

--- a/src/models/common_replacement.ts
+++ b/src/models/common_replacement.ts
@@ -1,0 +1,347 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+// basically copied from cactbot
+// Licensed at Apache License 2.0
+
+// TODO: maybe this should be structured identically to a timelineReplace section.
+
+import { CommonReplacement } from "./trigger";
+
+// It's awkward to refer to these string keys, so name them as replaceSync[keys.sealKey].
+export const syncKeys = {
+  seal: '(?<=00:0839:)(.*) will be sealed off(?: in (?:[0-9]+ seconds)?)?',
+  unseal: 'is no longer sealed',
+  engage: 'Engage!',
+};
+
+const textKeys = {
+  // Match directions in replaceText
+  // eg: `(N)`, `(SW)`, `(NE/NW)`, etc.
+  E: '(?<= \\(|\\/)E(?=\\)|\\/)',
+  N: '(?<= \\(|\\/)N(?=\\)|\\/)',
+  S: '(?<= \\(|\\/)S(?=\\)|\\/)',
+  W: '(?<= \\(|\\/)W(?=\\)|\\/)',
+  NE: '(?<= \\(|\\/)NE(?=\\)|\\/)',
+  NW: '(?<= \\(|\\/)NW(?=\\)|\\/)',
+  SE: '(?<= \\(|\\/)SE(?=\\)|\\/)',
+  SW: '(?<= \\(|\\/)SW(?=\\)|\\/)',
+  // Match Roles in replaceText
+  // eg: `(Tank)`, `(Healer)`, `(DPS)`, etc
+  Tank: '(?<= \\(|\\/)Tanks?(?=\\)|\\/)',
+  Healer: '(?<= \\(|\\/)Healers?(?=\\)|\\/)',
+  DPS: '(?<= \\(|\\/)DPS(?=\\)|\\/)',
+  // Match `--1--` style text.
+  Number: '--(\\s*\\d+\\s*)--',
+};
+
+export const commonReplacement: CommonReplacement = {
+  replaceSync: {
+    [syncKeys.seal]: {
+      en: '$1 will be sealed off',
+      de: 'Noch 15 Sekunden, bis sich (?:(?:der|die|das) )?(?:Zugang zu(?:[rm]| den)? )?$1 schließt',
+      fr: 'Fermeture d(?:e|u|es) $1 dans',
+      ja: '$1の封鎖まであと',
+      cn: '距$1被封锁还有',
+      ko: '15초 후에 $1(?:이|가) 봉쇄됩니다',
+    },
+    [syncKeys.unseal]: {
+      en: 'is no longer sealed',
+      de: 'öffnet sich (?:wieder|erneut)',
+      fr: 'Ouverture ',
+      ja: 'の封鎖が解かれた',
+      cn: '的封锁解除了',
+      ko: '의 봉쇄가 해제되었습니다',
+    },
+    [syncKeys.engage]: {
+      en: 'Engage!',
+      de: 'Start!',
+      fr: 'À l\'attaque',
+      ja: '戦闘開始！',
+      cn: '战斗开始！',
+      ko: '전투 시작!',
+    },
+  },
+  replaceText: {
+    '--adds spawn--': {
+      de: '--adds spawn--',
+      fr: '--apparition d\'adds--',
+      ja: '--雑魚出現--',
+      cn: '--小怪出现--',
+      ko: '--쫄 소환--',
+    },
+    '--adds targetable--': {
+      de: '--adds anvisierbar--',
+      fr: '--adds ciblables--',
+      ja: '--雑魚ターゲット可能--',
+      cn: '--小怪可选中--',
+      ko: '--쫄 타겟 가능--',
+    },
+    '--center--': {
+      de: '--mitte--',
+      fr: '--centre--',
+      ja: '--センター--',
+      cn: '--中央--',
+      ko: '--중앙--',
+    },
+    '--clones appear--': {
+      de: '--klone erscheinen--',
+      fr: '--apparition des clones--',
+      ja: '--幻影出現--',
+      cn: '--克隆 体 出现--',
+      ko: '--분신 소환--',
+    },
+    '--corner--': {
+      de: '--ecke--',
+      fr: '--coin--',
+      ja: '--コーナー--',
+      cn: '--角落--',
+      ko: '--구석--',
+    },
+    '--dps burn--': {
+      de: '--dps burn--',
+      fr: '--burn dps--',
+      ja: '--火力出せ--',
+      cn: '--转火--',
+      ko: '--딜 체크--',
+    },
+    '--east--': {
+      de: '--osten--',
+      fr: '--est--',
+      ja: '--東--',
+      cn: '--东--',
+      ko: '--동쪽--',
+    },
+    'Enrage': {
+      de: 'Finalangriff',
+      fr: 'Enrage',
+      ja: '時間切れ',
+      cn: '狂暴',
+      ko: '전멸기',
+    },
+    '--jump--': {
+      de: '--sprung--',
+      fr: '--saut--',
+      ja: '--ジャンプ--',
+      cn: '--跳--',
+      ko: '--점프--',
+    },
+    '--knockback--': {
+      de: '--knockback--',
+      fr: '--poussée--',
+      ja: '--ノックバック--',
+      cn: '--击退--',
+      ko: '--넉백--',
+    },
+    '--middle--': {
+      de: '--mitte--',
+      fr: '--milieu--',
+      ja: '--中央--',
+      cn: '--中间--',
+      ko: '--중앙--',
+    },
+    '--north--': {
+      de: '--norden--',
+      fr: '--nord--',
+      ja: '--北--',
+      cn: '--北--',
+      ko: '--북쪽--',
+    },
+    '--northeast--': {
+      de: '--nordosten--',
+      fr: '--nord-est--',
+      ja: '--北東--',
+      cn: '--东北--',
+      ko: '--북동--',
+    },
+    '--northwest--': {
+      de: '--nordwesten--',
+      fr: '--nord-ouest--',
+      ja: '--北西--',
+      cn: '--西北--',
+      ko: '--북서--',
+    },
+    '--rotate--': {
+      de: '--rotieren--',
+      fr: '--rotation--',
+      ja: '--回転--',
+      cn: '--龙回转--',
+      ko: '--회전--',
+    },
+    '--south--': {
+      de: '--süden--',
+      fr: '--sud--',
+      ja: '--南--',
+      cn: '--南--',
+      ko: '--남쪽--',
+    },
+    '--southeast--': {
+      de: '--südosten--',
+      fr: '--sud-est--',
+      ja: '--南東--',
+      cn: '--东南--',
+      ko: '--남동--',
+    },
+    '--southwest--': {
+      de: '--südwesten--',
+      fr: '--sud-ouest--',
+      ja: '--南西--',
+      cn: '--西南--',
+      ko: '--남서--',
+    },
+    '--split--': {
+      de: '--teilen--',
+      fr: '--division--',
+      ja: '--分裂--',
+      cn: '--分裂--',
+      ko: '--분열--',
+    },
+    '--stun--': {
+      de: '--Betäubung--',
+      fr: '--étourdissement--',
+      ja: '--スタン--',
+      cn: '--击晕--',
+      ko: '--기절--',
+    },
+    '--sync--': {
+      de: '--synchronisation--',
+      fr: '--synchronisation--',
+      ja: '--シンク--',
+      cn: '--同步化--',
+      ko: '--동기화--',
+    },
+    '--([0-9]+x )?targetable--': {
+      de: '--$1anvisierbar--',
+      fr: '--$1ciblable--',
+      ja: '--$1ターゲット可能--',
+      cn: '--$1可选中--',
+      ko: '--$1타겟 가능--',
+    },
+    '--teleport--': {
+      de: '--teleportation--',
+      fr: '--téléportation--',
+      ja: '--テレポート--',
+      cn: '--傳送--',
+      ko: '--순간 이동--',
+    },
+    '--untargetable--': {
+      de: '--nich anvisierbar--',
+      fr: '--non ciblable--',
+      ja: '--ターゲット不可--',
+      cn: '--无法选中--',
+      ko: '--타겟 불가능--',
+    },
+    '--west--': {
+      de: '--westen--',
+      fr: '--ouest--',
+      ja: '--西--',
+      cn: '--西--',
+      ko: '--서쪽--',
+    },
+    [textKeys.E]: {
+      de: 'O',
+      fr: 'E',
+      ja: '東',
+      cn: '东',
+      ko: '동',
+    },
+    [textKeys.N]: {
+      de: 'N',
+      fr: 'N',
+      ja: '北',
+      cn: '北',
+      ko: '북',
+    },
+    [textKeys.S]: {
+      de: 'S',
+      fr: 'S',
+      ja: '南',
+      cn: '南',
+      ko: '남',
+    },
+    [textKeys.W]: {
+      de: 'W',
+      fr: 'O',
+      ja: '西',
+      cn: '西',
+      ko: '서',
+    },
+    [textKeys.NE]: {
+      de: 'NO',
+      fr: 'NE',
+      ja: '北東',
+      cn: '东北',
+      ko: '북동',
+    },
+    [textKeys.NW]: {
+      de: 'NW',
+      fr: 'NO',
+      ja: '北西',
+      cn: '西北',
+      ko: '북서',
+    },
+    [textKeys.SE]: {
+      de: 'SO',
+      fr: 'SE',
+      ja: '南東',
+      cn: '东南',
+      ko: '남동',
+    },
+    [textKeys.SW]: {
+      de: 'SW',
+      fr: 'SO',
+      ja: '南西',
+      cn: '西南',
+      ko: '남서',
+    },
+    [textKeys.Tank]: {
+      de: 'Tank',
+      fr: 'Tank',
+      ja: 'タンク',
+      cn: '坦克',
+      ko: '탱커',
+    },
+    [textKeys.Healer]: {
+      de: 'Heiler',
+      fr: 'Healer',
+      ja: 'ヒーラー',
+      cn: '治疗',
+      ko: '힐러',
+    },
+    [textKeys.DPS]: {
+      de: 'DPS',
+      fr: 'DPS',
+      ja: 'DPS',
+      cn: 'DPS',
+      ko: '딜러',
+    },
+    [textKeys.Number]: {
+      de: '--$1--',
+      fr: '--$1--',
+      ja: '--$1--',
+      cn: '--$1--',
+      ko: '--$1--',
+    },
+  },
+};
+
+// Keys into commonReplacement objects that represent "partial" translations,
+// in the sense that even if it applies, there still needs to be another
+// translation for it to be complete.  These keys should be exactly the same
+// as the keys from the commonReplacement block above.
+export const partialCommonReplacementKeys = [
+  // Because the zone name needs to be translated here, this is partial.
+  syncKeys.seal,
+  // Directions
+  textKeys.E,
+  textKeys.N,
+  textKeys.S,
+  textKeys.W,
+  textKeys.NE,
+  textKeys.NW,
+  textKeys.SE,
+  textKeys.SW,
+  // Roles
+  textKeys.Tank,
+  textKeys.Healer,
+  textKeys.DPS,
+];

--- a/src/models/trigger.ts
+++ b/src/models/trigger.ts
@@ -23,13 +23,17 @@ export interface Replacement {
   [s: string]: string;
 };
 
+export type CommonReplacementWithEnItem = {
+  [s in keyof Locale]: string;
+};
+
 export type CommonReplacementItem = {
   [s in Exclude<keyof Locale, "en">]: string;
 };
 
 export interface CommonReplacement {
   replaceText: { [s: string]: CommonReplacementItem };
-  replaceSync: { [s: string]: CommonReplacementItem };
+  replaceSync: { [s: string]: CommonReplacementWithEnItem };
 };
 
 export interface CommonReplacementModule {

--- a/src/translateTimeline.ts
+++ b/src/translateTimeline.ts
@@ -3,9 +3,6 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 import * as babel from "@babel/core";
 import generator from "@babel/generator";
-const esmRequire = require("esm")(module, {
-  mode: "all",
-});
 import { NodeVM } from "vm2";
 
 import {
@@ -18,7 +15,7 @@ import { commonReplacement } from "./models/common_replacement";
 
 export const sandboxWrapper = async (
   triggerPath: string,
-): Promise<{ timelineReplaceList: TimelineReplace[], commonReplacement: CommonReplacement }> => {
+): Promise<TimelineReplace[]> => {
 
   return new Promise((resolve, reject) => {
 
@@ -27,19 +24,12 @@ export const sandboxWrapper = async (
     const vm = new NodeVM({
       sandbox: {
         triggerPath,
-        commonPath: cwd + "/ui/raidboss/common_replacement.js",
         babel,
         generator,
         fs,
-        esmRequire,
         callback: (timelineReplaceList: TimelineReplace[]) => {
-          resolve({ timelineReplaceList, commonReplacement });
+          resolve(timelineReplaceList);
         },
-      },
-      require: {
-        external: true,
-        builtin: [],
-        root: cwd,
       },
     });
 
@@ -78,12 +68,12 @@ export class TranslatedTimelineProvider implements vscode.TextDocumentContentPro
     const locale = uri.query;
 
     try {
-      const result = await sandboxWrapper(triggerFilePath);
+      const timelineReplaceList = await sandboxWrapper(triggerFilePath);
       return this.translate({
         locale: locale as keyof Locale,
         timelineFile: String(fs.readFileSync(timelineFilePath)),
-        timelineReplaceList: result.timelineReplaceList,
-        commonReplace: result.commonReplacement,
+        timelineReplaceList,
+        commonReplace: commonReplacement,
       });
     } catch (e) {
       const err = e as Error;

--- a/src/translateTimeline.ts
+++ b/src/translateTimeline.ts
@@ -3,7 +3,9 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 import * as babel from "@babel/core";
 import generator from "@babel/generator";
-const esmRequire = require("esm")(module);
+const esmRequire = require("esm")(module, {
+  mode: "all",
+});
 import { NodeVM } from "vm2";
 
 import {
@@ -11,6 +13,8 @@ import {
   Locale, Replacement,
   TimelineReplace,
 } from "./models/trigger";
+
+import { commonReplacement } from "./models/common_replacement";
 
 export const sandboxWrapper = async (
   triggerPath: string,
@@ -28,7 +32,7 @@ export const sandboxWrapper = async (
         generator,
         fs,
         esmRequire,
-        callback: (timelineReplaceList: TimelineReplace[], commonReplacement: CommonReplacement) => {
+        callback: (timelineReplaceList: TimelineReplace[]) => {
           resolve({ timelineReplaceList, commonReplacement });
         },
       },
@@ -54,9 +58,7 @@ babel.traverse(babel.parseSync(String(fs.readFileSync(triggerPath))), {
 const timelineReplaceCode = generator(node).code.substring("timelineReplace: ".length);
 const timelineReplaceJson = eval(timelineReplaceCode);
 
-const commonReplacement = esmRequire(commonPath).commonReplacement;
-
-callback(timelineReplaceJson, commonReplacement);
+callback(timelineReplaceJson);
                 `, cwd + '/index.js');
     } catch (err) {
       reject(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,11 +1855,6 @@ eslint@^7.9.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25:
-  version "3.2.25"
-  resolved "https://registry.npm.taobao.org/esm/download/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha1-NCwYwp1WFXaIulzjH4Qx+7eVzBA=
-
 espree@^7.3.0:
   version "7.3.0"
   resolved "https://registry.npm.taobao.org/espree/download/espree-7.3.0.tgz?cache=0&sync_timestamp=1598129987642&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fespree%2Fdownload%2Fespree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"


### PR DESCRIPTION
take common_replacement.js from cactbot,
bundled in this extension, so don't need esm anymore.