### PR TITLE
refactor: use ts transformer to instead of babel to get replace texts

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,9 +145,13 @@
     }
   },
   "devDependencies": {
+    "@babel/core": "^7.23.6",
     "@babel/cli": "^7.23.4",
+    "@babel/generator": "^7.23.0",
+    "@babel/plugin-transform-typescript": "^7.22.11",
     "@babel/preset-env": "^7.23.5",
     "@babel/preset-typescript": "^7.23.2",
+    "@babel/types": "^7.21.3",
     "@crowdin/cli": "^3.13.0",
     "@types/babel__core": "^7.20.5",
     "@types/event-stream": "^4.0.5",
@@ -184,10 +188,6 @@
     "vscode-test": "^1.6.1"
   },
   "dependencies": {
-    "@babel/core": "^7.23.6",
-    "@babel/generator": "^7.23.0",
-    "@babel/plugin-transform-typescript": "^7.22.11",
-    "@babel/types": "^7.21.3",
     "typescript": "^4.9.5",
     "vscode-nls": "^5.2.0"
   },


### PR DESCRIPTION
This PR uses the TypeScript [transformer](https://basarat.gitbook.io/typescript/overview/ast) feature to get `replaceSync` and `replaceText` from Cactbot source files, instead of the old/slow babel one.