### PR TITLE
chore: enable shallow checkout for cactbot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "3rdparty/cactbot"]
 	path = 3rdparty/cactbot
 	url = https://github.com/OverlayPlugin/cactbot.git
+	shallow = true


### PR DESCRIPTION
This would significantly reduce the size of the whole repository, especially when you enable the `sparse-checkout` feature to only checkout the subset like below:

```
resources/*.ts
types/
ui/
package*.json
tsconfig.json
```

But you'll need to manually type `git submodule update --depth <number>` to enable it.