### PR TITLE
fix: timeline translate feature broken in some timeline

### DIFF
--- a/src/timeline/translate.ts
+++ b/src/timeline/translate.ts
@@ -184,6 +184,7 @@ export class TranslatedTimelineProvider implements TextDocumentContentProvider {
 
         const matchLogTypeByName = ['AddedCombatant', 'RemovedCombatant']
         const matchLogTypeSource = [
+          'InCombat',
           'StartsUsing',
           'Ability',
           'NetworkAOEAbility',


### PR DESCRIPTION
Because those timelines have a `timelineReplace` object with quoted keys and some are not, e.g `'locale': 'de'` vs `locale: 'de'`, the original code only accepts the unquoted ones. This PR would resolve this issue in a naive way, this should be implemented better in the future!

Fix #488 
Fix #483 